### PR TITLE
Fixes #8 marklogic-rdf4j now uses the database specified during initi…

### DIFF
--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClient.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClient.java
@@ -90,8 +90,8 @@ public class MarkLogicClient {
 	 * Constructor initialized with connection parameters.
 	 *
 	 */
-	public MarkLogicClient(String host, int port, String user, String password,String auth) {
-		this._client = new MarkLogicClientImpl(host,port,user,password,auth);
+	public MarkLogicClient(String host, int port, String user, String password, String database, String auth) {
+		this._client = new MarkLogicClientImpl(host, port, user, password, database, auth);
 		this.initTimer();
 	}
 

--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClientImpl.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/client/MarkLogicClientImpl.java
@@ -94,12 +94,8 @@ class MarkLogicClientImpl {
      * @param password
      * @param auth
      */
-    public MarkLogicClientImpl(String host, int port, String user, String password, String auth) {
-        try {
-            setDatabaseClient(util.getClientBasedOnAuth(host, port, user, password, auth));
-        } catch (UnrecoverableKeyException | CertificateException | KeyManagementException | IOException e) {
-            e.printStackTrace();
-        }
+    public MarkLogicClientImpl(String host, int port, String user, String password, String database, String auth) {
+        setDatabaseClient(util.getClientBasedOnAuth(host, port, user, password, database, auth));
     }
 
     /**

--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/query/MarkLogicQuery.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/query/MarkLogicQuery.java
@@ -27,7 +27,6 @@ import com.marklogic.semantics.rdf4j.client.MarkLogicClient;
 import com.marklogic.semantics.rdf4j.client.MarkLogicClientDependent;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.Dataset;
 import org.eclipse.rdf4j.query.Query;
 import org.eclipse.rdf4j.query.impl.AbstractQuery;

--- a/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/utils/Util.java
+++ b/marklogic-rdf4j/src/main/java/com/marklogic/semantics/rdf4j/utils/Util.java
@@ -6,6 +6,8 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.UnrecoverableKeyException;
@@ -93,37 +95,29 @@ public class Util {
                 || dataFormat.equals(RDFFormat.N3);
     }
 
+    public DatabaseClient getClientBasedOnAuth(String host, int port, String database, DatabaseClientFactory.SecurityContext securityContext)
+    {
+        return DatabaseClientFactory.newClient(host, port, database, securityContext);
+    }
+
     /**
      * Public utility that returns DatabaseClient based on auth
      * @return DatabaseClient
      */
-    public DatabaseClient getClientBasedOnAuth(String host, int port, String user, String password, String auth, String... cert) throws UnrecoverableKeyException, CertificateException, KeyManagementException, IOException {
+    public DatabaseClient getClientBasedOnAuth(String host, int port, String user, String password, String database, String auth) {
         Authentication type;
-        String certFile;
-        String certPassword;
 
         if(auth != null)
         {
             type = Authentication.valueOfUncased(auth);
-            certFile = cert.length > 0 ? cert[0] : "";
-            certPassword = cert.length > 1 ? cert[1] : "";
 
             if(type == Authentication.BASIC)
             {
-                return DatabaseClientFactory.newClient(host, port, new DatabaseClientFactory.BasicAuthContext(user, password));
+                return DatabaseClientFactory.newClient(host, port, database, new DatabaseClientFactory.BasicAuthContext(user, password));
             }
             else if(type == Authentication.DIGEST)
             {
                 return DatabaseClientFactory.newClient(host, port, new DatabaseClientFactory.DigestAuthContext(user, password));
-            }
-            else if(type == Authentication.KERBEROS)
-            {
-                return DatabaseClientFactory.newClient(host, port, new DatabaseClientFactory.KerberosAuthContext());
-            }
-            else if(type == Authentication.CERTIFICATE)
-            {
-                //TODO: change parameters
-                return DatabaseClientFactory.newClient(host, port, new DatabaseClientFactory.CertificateAuthContext(certFile, certPassword));
             }
         }
 

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicExceptionsTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicExceptionsTest.java
@@ -73,7 +73,8 @@ public class MarkLogicExceptionsTest extends Rdf4jTestBase {
         logger.debug("tearing down...");
         conn.close();
         conn = null;
-        rep.shutDown();
+        // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+        //rep.shutDown();
         rep = null;
         logger.info("tearDown complete.");
     }

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicGraphPermsTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicGraphPermsTest.java
@@ -85,7 +85,8 @@ public class MarkLogicGraphPermsTest extends Rdf4jTestBase {
         logger.debug("tearing down...");
         conn.close();
         conn = null;
-        rep.shutDown();
+        // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+        //rep.shutDown();
         rep = null;
         logger.info("tearDown complete.");
 

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryCacheTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryCacheTest.java
@@ -72,7 +72,8 @@ public class MarkLogicRepositoryCacheTest extends Rdf4jTestBase {
         if(conn.isOpen()){conn.clear();}
         conn.close();
         conn = null;
-        rep.shutDown();
+        // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+        //rep.shutDown();
         rep = null;
         logger.info("tearDown complete.");
     }

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryConnectionTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryConnectionTest.java
@@ -19,6 +19,8 @@
  */
 package com.marklogic.semantics.rdf4j;
 
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.DatabaseClientFactory;
 import com.marklogic.semantics.rdf4j.config.MarkLogicRepositoryConfig;
 import com.marklogic.semantics.rdf4j.config.MarkLogicRepositoryFactory;
 
@@ -93,7 +95,8 @@ public class MarkLogicRepositoryConnectionTest extends Rdf4jTestBase {
         //conn.clear();
         if(conn.isOpen()){conn.clear();}
         conn.close();
-        rep.shutDown();
+        // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+        //rep.shutDown();
         conn=null;
         logger.info("tearDown complete.");
     }
@@ -1432,6 +1435,142 @@ public class MarkLogicRepositoryConnectionTest extends Rdf4jTestBase {
         result = conn.getStatements(null, null, null, null);
         model = Iterations.addAll(result, new LinkedHashModel());
         Assert.assertEquals(0, model.size());
+    }
+
+    @Test
+    public void testConnectionWithMLClientApiObjectWithDatabase()
+    {
+        DatabaseClient databaseClient = DatabaseClientFactory.newClient(host, port, "marklogic-rdf4j-test-content", new DatabaseClientFactory.DigestAuthContext(user, password));
+        MarkLogicRepository markLogicRepository = new MarkLogicRepository(databaseClient);
+        markLogicRepository.initialize();
+        MarkLogicRepositoryConnection con = markLogicRepository.getConnection();
+        ValueFactory vf =  con.getValueFactory();
+        Resource context10 = vf.createIRI("http://marklogic.com/test/context10");
+        IRI alice = vf.createIRI("http://example.org/people/alice");
+        IRI name = vf.createIRI("http://example.org/ontology/name");
+        Literal alicesName = vf.createLiteral("Alice");
+        con.begin();
+        con.add(alice, name, alicesName, context10);
+        con.commit();
+        RepositoryResult<Statement> result = con.getStatements(alice, null, null, context10);
+        Model model = Iterations.addAll(result, new LinkedHashModel());
+        Assert.assertEquals(1, model.size());
+
+        markLogicRepository.shutDown();
+        markLogicRepository.initialize();
+        con = markLogicRepository.getConnection();
+        result = con.getStatements(alice, null, null, context10);
+        model = Iterations.addAll(result, new LinkedHashModel());
+        Assert.assertEquals(1, model.size());
+        con.clear();
+    }
+
+    @Test
+    public void testConnectionWithMLConnectionVariablesWithoutDatabase()
+    {
+        MarkLogicRepository markLogicRepository = new MarkLogicRepository(host, port, user, password, "DIGEST");
+        markLogicRepository.initialize();
+        MarkLogicRepositoryConnection con = markLogicRepository.getConnection();
+        ValueFactory vf =  con.getValueFactory();
+        Resource context10 = vf.createIRI("http://marklogic.com/test/context10");
+        IRI alice = vf.createIRI("http://example.org/people/alice");
+        IRI name = vf.createIRI("http://example.org/ontology/name");
+        Literal alicesName = vf.createLiteral("Alice");
+        con.begin();
+        con.add(alice, name, alicesName, context10);
+        con.commit();
+        RepositoryResult<Statement> result = con.getStatements(alice, null, null, context10);
+        Model model = Iterations.addAll(result, new LinkedHashModel());
+        Assert.assertEquals(1, model.size());
+
+        markLogicRepository.shutDown();
+        markLogicRepository.initialize();
+        con = markLogicRepository.getConnection();
+        result = con.getStatements(alice, null, null, context10);
+        model = Iterations.addAll(result, new LinkedHashModel());
+        Assert.assertEquals(1, model.size());
+        con.clear();
+    }
+
+    @Test
+    public void testConnectionWithMLConnectionVariablesWithDatabase()
+    {
+        MarkLogicRepository markLogicRepository = new MarkLogicRepository(host, port, user, password, "marklogic-rdf4j-test-content", "DIGEST");
+        markLogicRepository.initialize();
+        MarkLogicRepositoryConnection con = markLogicRepository.getConnection();
+        ValueFactory vf =  con.getValueFactory();
+        Resource context11 = vf.createIRI("http://marklogic.com/test/context11");
+        IRI alice = vf.createIRI("http://example.org/people/alice");
+        IRI name = vf.createIRI("http://example.org/ontology/name");
+        Literal alicesName = vf.createLiteral("Alice");
+        con.begin();
+        con.add(alice, name, alicesName, context11);
+        con.commit();
+        RepositoryResult<Statement> result = con.getStatements(alice, null, null, context11);
+        Model model = Iterations.addAll(result, new LinkedHashModel());
+        Assert.assertEquals(1, model.size());
+
+        markLogicRepository.shutDown();
+        markLogicRepository.initialize();
+        con = markLogicRepository.getConnection();
+        result = con.getStatements(alice, null, null, context11);
+        model = Iterations.addAll(result, new LinkedHashModel());
+        Assert.assertEquals(1, model.size());
+        con.clear();
+    }
+
+    @Test
+    public void testConnectionWithMLClientApiSecurityContextWithoutDatabase()
+    {
+        MarkLogicRepository markLogicRepository = new MarkLogicRepository(host, port, new DatabaseClientFactory.DigestAuthContext(user, password));
+        markLogicRepository.initialize();
+        MarkLogicRepositoryConnection con = markLogicRepository.getConnection();
+        ValueFactory vf =  con.getValueFactory();
+        Resource context12 = vf.createIRI("http://marklogic.com/test/context12");
+        IRI alice = vf.createIRI("http://example.org/people/alice");
+        IRI name = vf.createIRI("http://example.org/ontology/name");
+        Literal alicesName = vf.createLiteral("Alice");
+        con.begin();
+        con.add(alice, name, alicesName, context12);
+        con.commit();
+        RepositoryResult<Statement> result = con.getStatements(alice, null, null, context12);
+        Model model = Iterations.addAll(result, new LinkedHashModel());
+        Assert.assertEquals(1, model.size());
+
+        markLogicRepository.shutDown();
+        markLogicRepository.initialize();
+        con = markLogicRepository.getConnection();
+        result = con.getStatements(alice, null, null, context12);
+        model = Iterations.addAll(result, new LinkedHashModel());
+        Assert.assertEquals(1, model.size());
+        con.clear();
+    }
+
+    @Test
+    public void testConnectionWithMLClientApiSecurityContextWithDatabase()
+    {
+        MarkLogicRepository markLogicRepository = new MarkLogicRepository(host, port, "marklogic-rdf4j-test-content", new DatabaseClientFactory.DigestAuthContext(user, password));
+        markLogicRepository.initialize();
+        MarkLogicRepositoryConnection con = markLogicRepository.getConnection();
+        ValueFactory vf =  con.getValueFactory();
+        Resource context12 = vf.createIRI("http://marklogic.com/test/context12");
+        IRI alice = vf.createIRI("http://example.org/people/alice");
+        IRI name = vf.createIRI("http://example.org/ontology/name");
+        Literal alicesName = vf.createLiteral("Alice");
+        con.begin();
+        con.add(alice, name, alicesName, context12);
+        con.commit();
+        RepositoryResult<Statement> result = con.getStatements(alice, null, null, context12);
+        Model model = Iterations.addAll(result, new LinkedHashModel());
+        Assert.assertEquals(1, model.size());
+
+        markLogicRepository.shutDown();
+        markLogicRepository.initialize();
+        con = markLogicRepository.getConnection();
+        result = con.getStatements(alice, null, null, context12);
+        model = Iterations.addAll(result, new LinkedHashModel());
+        Assert.assertEquals(1, model.size());
+        con.clear();
     }
 }
 

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryTest.java
@@ -56,7 +56,8 @@ public class MarkLogicRepositoryTest extends Rdf4jTestBase {
         rep.initialize();
 
         Assert.assertTrue(rep instanceof Repository);
-        rep.shutDown();
+        // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+        //rep.shutDown();
     }
 
     @Test
@@ -114,7 +115,8 @@ public class MarkLogicRepositoryTest extends Rdf4jTestBase {
         RepositoryConnection conn = rep.getConnection();
         Assert.assertTrue(conn instanceof RepositoryConnection);
         conn.close();
-        rep.shutDown();
+        // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+        //rep.shutDown();
     }
 
     @Test

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryTransactionTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/MarkLogicRepositoryTransactionTest.java
@@ -69,7 +69,8 @@ public class MarkLogicRepositoryTransactionTest extends Rdf4jTestBase {
         if(conn.isOpen()){conn.clear();}
         conn.close();
         conn = null;
-        rep.shutDown();
+        // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+        //rep.shutDown();
         rep = null;
         logger.info("tearDown complete.");
     }

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/query/MarkLogicBooleanQueryTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/query/MarkLogicBooleanQueryTest.java
@@ -67,7 +67,8 @@ public class MarkLogicBooleanQueryTest extends Rdf4jTestBase {
         logger.debug("tearing down...");
         conn.close();
         conn = null;
-        rep.shutDown();
+        // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+        //rep.shutDown();
         rep = null;
         logger.info("tearDown complete.");
         GraphManager gmgr = writerClient.newGraphManager();

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/query/MarkLogicCombinationQueryTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/query/MarkLogicCombinationQueryTest.java
@@ -93,7 +93,8 @@ public class MarkLogicCombinationQueryTest extends Rdf4jTestBase {
         logger.debug("tearing down...");
         conn.close();
         conn = null;
-        rep.shutDown();
+        // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+        //rep.shutDown();
         rep = null;
         logger.info("tearDown complete.");
 

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/query/MarkLogicGraphQueryTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/query/MarkLogicGraphQueryTest.java
@@ -72,7 +72,8 @@ public class MarkLogicGraphQueryTest extends Rdf4jTestBase {
         logger.debug("tearing down...");
         conn.close();
         conn = null;
-        rep.shutDown();
+        // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+        //rep.shutDown();
         rep = null;
         logger.info("tearDown complete.");
         GraphManager gmgr = writerClient.newGraphManager();

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/query/MarkLogicTupleQueryTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/query/MarkLogicTupleQueryTest.java
@@ -85,7 +85,11 @@ public class MarkLogicTupleQueryTest extends Rdf4jTestBase {
         logger.debug("tearing down...");
         if(conn != null){conn.close();}
         conn = null;
-        if(rep != null){rep.shutDown();}
+        if(rep != null)
+        {
+            // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+            //rep.shutDown();
+        }
         rep = null;
         logger.info("tearDown complete.");
         GraphManager gmgr = writerClient.newGraphManager();

--- a/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/query/MarkLogicUpdateQueryTest.java
+++ b/marklogic-rdf4j/src/test/java/com/marklogic/semantics/rdf4j/query/MarkLogicUpdateQueryTest.java
@@ -67,7 +67,8 @@ public class MarkLogicUpdateQueryTest extends Rdf4jTestBase {
         logger.debug("tearing down...");
         conn.close();
         conn = null;
-        rep.shutDown();
+        // TODO: Un-comment line when issue 811 gets resolved. https://github.com/marklogic/java-client-api/issues/811
+        //rep.shutDown();
         rep = null;
         logger.info("tearDown complete.");
         GraphManager gmgr = writerClient.newGraphManager();


### PR DESCRIPTION
-Fixes #8 marklogic-rdf4j now uses the database specified during initialization instead of using the App server default.
-Updated and added different ways to initialize MarkLogicRepository so as to accommodate the different "Auths" supported by MarkLogic Java Client API.
-Optimized "mlrepo.initializeInternal()" so that it doesn't establish a new connection with MarkLogic Java Client API, if a live connection already exists.
-Added relevant unit tests.
-Removed unused imports.
-Updated unit tests to ignore calling shutdown on repo twice until Issue #811 gets resolved. https://github.com/marklogic/java-client-api/issues/811